### PR TITLE
AppColor & AppFont로 파일 생성후 작업했던 내용 수정

### DIFF
--- a/BeTime/BeTime.xcodeproj/project.pbxproj
+++ b/BeTime/BeTime.xcodeproj/project.pbxproj
@@ -20,8 +20,8 @@
 		29894DF42C75D152002A08DF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 29894DF32C75D152002A08DF /* Assets.xcassets */; };
 		29894DF72C75D152002A08DF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 29894DF52C75D152002A08DF /* LaunchScreen.storyboard */; };
 		29B91D162C9404D40048D0D0 /* LaunchScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B91D152C9404D40048D0D0 /* LaunchScreenViewController.swift */; };
-		29B91D182C940E2A0048D0D0 /* AppColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B91D172C940E2A0048D0D0 /* AppColors.swift */; };
-		29B91D1D2C941D310048D0D0 /* AppFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B91D1C2C941D310048D0D0 /* AppFont.swift */; };
+		29B91D182C940E2A0048D0D0 /* BaseColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B91D172C940E2A0048D0D0 /* BaseColor.swift */; };
+		29B91D1D2C941D310048D0D0 /* BaseFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B91D1C2C941D310048D0D0 /* BaseFont.swift */; };
 		29EEFAD12C7892BC00BEBE78 /* WeatherResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EEFAD02C7892BC00BEBE78 /* WeatherResponseDTO.swift */; };
 		29EEFAD32C78A29400BEBE78 /* LocationCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EEFAD22C78A29400BEBE78 /* LocationCore.swift */; };
 		29EEFAD82C78A3E200BEBE78 /* WeatherForecast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EEFAD72C78A3E200BEBE78 /* WeatherForecast.swift */; };
@@ -54,8 +54,8 @@
 		29894DF62C75D152002A08DF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		29894DF82C75D152002A08DF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		29B91D152C9404D40048D0D0 /* LaunchScreenViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchScreenViewController.swift; sourceTree = "<group>"; };
-		29B91D172C940E2A0048D0D0 /* AppColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppColors.swift; sourceTree = "<group>"; };
-		29B91D1C2C941D310048D0D0 /* AppFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFont.swift; sourceTree = "<group>"; };
+		29B91D172C940E2A0048D0D0 /* BaseColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseColor.swift; sourceTree = "<group>"; };
+		29B91D1C2C941D310048D0D0 /* BaseFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseFont.swift; sourceTree = "<group>"; };
 		29EEFAD02C7892BC00BEBE78 /* WeatherResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherResponseDTO.swift; sourceTree = "<group>"; };
 		29EEFAD22C78A29400BEBE78 /* LocationCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationCore.swift; sourceTree = "<group>"; };
 		29EEFAD72C78A3E200BEBE78 /* WeatherForecast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherForecast.swift; sourceTree = "<group>"; };
@@ -136,8 +136,8 @@
 			isa = PBXGroup;
 			children = (
 				29894DF32C75D152002A08DF /* Assets.xcassets */,
-				29B91D172C940E2A0048D0D0 /* AppColors.swift */,
-				29B91D1C2C941D310048D0D0 /* AppFont.swift */,
+				29B91D172C940E2A0048D0D0 /* BaseColor.swift */,
+				29B91D1C2C941D310048D0D0 /* BaseFont.swift */,
 				291E0C5E2C959E6500B820CD /* CityList.swift */,
 			);
 			path = Resource;
@@ -424,8 +424,8 @@
 				290E26A42C92066C0091C8B3 /* MainTabBarController.swift in Sources */,
 				29894DED2C75D150002A08DF /* SceneDelegate.swift in Sources */,
 				29EEFADA2C78A56600BEBE78 /* Location.swift in Sources */,
-				29B91D1D2C941D310048D0D0 /* AppFont.swift in Sources */,
-				29B91D182C940E2A0048D0D0 /* AppColors.swift in Sources */,
+				29B91D1D2C941D310048D0D0 /* BaseFont.swift in Sources */,
+				29B91D182C940E2A0048D0D0 /* BaseColor.swift in Sources */,
 				291E0C5F2C959E6500B820CD /* CityList.swift in Sources */,
 				29EEFB1D2C80700300BEBE78 /* WeatherDataRepositoryProtocol.swift in Sources */,
 				290E26A62C920CD30091C8B3 /* UserWeatherTableViewCell.swift in Sources */,

--- a/BeTime/BeTime/Resource/BaseColor.swift
+++ b/BeTime/BeTime/Resource/BaseColor.swift
@@ -9,7 +9,7 @@ import UIKit
 
 extension UIColor {
 
-  static let appBackgroundColor: UIColor = {
+  static let beTimeBackgroundColor: UIColor = {
     return UIColor(red: 160/255, green: 194/255, blue: 204/255, alpha: 1.0)
   }()
 

--- a/BeTime/BeTime/Resource/BaseFont.swift
+++ b/BeTime/BeTime/Resource/BaseFont.swift
@@ -9,15 +9,15 @@ import UIKit
 
 extension UIFont {
 
-  static let appTitleFont: UIFont = {
+  static let beTimeTitleFont: UIFont = {
     return UIFont.systemFont(ofSize: 25)
   }()
 
-  static let appSubTitleFont: UIFont = {
+  static let beTimeSubTitleFont: UIFont = {
     return UIFont.systemFont(ofSize: 20)
   }()
 
-  static let appValueFont: UIFont = {
+  static let beTimeValueFont: UIFont = {
     return UIFont.systemFont(ofSize: 15)
   }()
 

--- a/BeTime/BeTime/Source/Scenes/LaunchScreenViewController.swift
+++ b/BeTime/BeTime/Source/Scenes/LaunchScreenViewController.swift
@@ -17,7 +17,7 @@ final class LaunchScreenViewController: UIViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    view.backgroundColor = .appBackgroundColor
+    view.backgroundColor = .beTimeBackgroundColor
     view.addSubview(launchScreenImageView)
 
     DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {

--- a/BeTime/BeTime/Source/Scenes/MainTabBarController.swift
+++ b/BeTime/BeTime/Source/Scenes/MainTabBarController.swift
@@ -35,7 +35,7 @@ final class MainTabBarController: UITabBarController {
     self.viewControllers = [userWeatherViewController, cityListViewController]
 
     let appearance = UITabBarAppearance()
-    appearance.backgroundColor = .appBackgroundColor
+    appearance.backgroundColor = .beTimeBackgroundColor
     tabBar.standardAppearance = appearance
     tabBar.scrollEdgeAppearance = appearance
   }

--- a/BeTime/BeTime/Source/Scenes/UserCityListScene/CityListViewController.swift
+++ b/BeTime/BeTime/Source/Scenes/UserCityListScene/CityListViewController.swift
@@ -14,7 +14,7 @@ import Then
 final class CityListContentView: UIView {
   let cityListTitleLabel = UILabel().then {
     $0.text = "날씨"
-    $0.font = UIFont.appTitleFont
+    $0.font = UIFont.beTimeTitleFont
   }
 
   var addCityButton = UIButton().then {
@@ -53,7 +53,7 @@ final class CityListContentView: UIView {
 
   let emptyMessageLabel = UILabel().then {
     $0.text = "도시를 추가해 주세요"
-    $0.font = UIFont.appValueFont
+    $0.font = UIFont.beTimeValueFont
     $0.textColor = .black
     $0.textAlignment = .center
     $0.isHidden = true
@@ -151,7 +151,7 @@ final class CityListViewController: UIViewController {
 
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
-    view.backgroundColor = .appBackgroundColor
+    view.backgroundColor = .beTimeBackgroundColor
   }
 
   private func setUpDelegate() {


### PR DESCRIPTION
# 이번 PR에서 한일
- AppColor&AppFont의 파일이름 수정
- Color & Font 이름 변경

# 고민됐던 부분
- beTimeValueFont로 수정을 하는데 접근시 UIFont인지 명시적으로 알게되는데 이름 뒤에 Font를 제거하는게 나을지
`$0.font = UIFont.beTimeValueFont` 현재
`$0.font = UIFont.beTimeValue` 생각
